### PR TITLE
Handle start and end date in async_get_events

### DIFF
--- a/custom_components/affalddk/calendar.py
+++ b/custom_components/affalddk/calendar.py
@@ -116,6 +116,11 @@ class AffaldDKCalendar(CoordinatorEntity[DataUpdateCoordinator], CalendarEntity)
 
             _pickup_events: PickupType = self._coordinator.data.pickup_events.get(item) if self._coordinator.data.pickup_events else None
 
+            if start_date.date() > _pickup_events.date:
+                continue
+            if end_date.date() < _pickup_events.date:
+                continue
+
             _summary = NAME_LIST.get(item)
             _start: datetime.date = _pickup_events.date
             _end: datetime.date = _start + timedelta(days=1)


### PR DESCRIPTION
I'm not a python dev, so not sure this is the best way of doing this - but I made this change locally in the process of trying to set up an automation and it seems to work :shrug: 

When requesting events home assistant might specify a start and end date that the events returned should be between (for example, if a user has an automation that calls calendar.get_events). The previous implementation ignored these values and so would always return a full set of events. This adds simple handling of those values to skip returning events that fall outside the range.

The range passed in by home assistant may include time data, but that is not handled here because we count all pickup events as taking the whole day.