### PR TITLE
Address lists in config flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@
 
 ### Changes
 
-* With version 2.6.0 the Next Pickup should change after the End time of the Pickup had passed. Unfortunately the Update Interval was not changed during that release. As of 2.7.0 update interval is now every hour and cannot be changed. This means every hour we check if end time has passed and if yes the Next Pickup will change to one after today. Data from the Garbage API is only loaded once a day, so we do not spam the providers.
+* With version 2.7.0 the Next Pickup should change after the End time of the Pickup had passed. Unfortunately the Update Interval was not changed during that release. As of 2.7.0 update interval is now every hour and cannot be changed. This means every hour we check if end time has passed and if yes the Next Pickup will change to one after today. Data from the Garbage API is only loaded once a day, so we do not spam the providers.
 * fix bug in set_next_pickup when only one fraction type
+* With version 2.7.0 searching for an address, will use only `roadname` and `zipcode` -  and `hourse_number` will be used as `house_numer` + wildcard to return a list of results for a new seconds selction step (if more than one result).
+
 * Fixed missing or failing Fractions in:
   * Dragør ([#321](https://github.com/briis/affalddk/issues/321))
   * Aalborg [#51](https://github.com/briis/pyaffalddk/issues/51)

--- a/custom_components/affalddk/calendar.py
+++ b/custom_components/affalddk/calendar.py
@@ -21,6 +21,7 @@ from homeassistant.util.dt import get_default_time_zone
 from pyaffalddk import NAME_LIST, PickupType
 from . import AffaldDKDataUpdateCoordinator
 from .const import (
+    CONF_ADDRESS,
     CONF_ADDRESS_ID,
     CONF_CALENDAR_END_TIME,
     CONF_CALENDAR_START_TIME,
@@ -76,12 +77,18 @@ class AffaldDKCalendar(CoordinatorEntity[DataUpdateCoordinator], CalendarEntity)
         super().__init__(coordinator)
         self._config = config
         self._coordinator = coordinator
+        name = DOMAIN.capitalize()
+        if CONF_ADDRESS in self._config.data:
+            name += f" {self._config.data[CONF_ADDRESS]}"
+        else:
+            # backwards compatible
+            name += f" {self._config.data[CONF_ROAD_NAME]} {self._config.data[CONF_HOUSE_NUMBER]}"
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._config.data[CONF_ADDRESS_ID])},
             entry_type=DeviceEntryType.SERVICE,
             manufacturer=DEFAULT_BRAND,
-            name=f"{DOMAIN.capitalize()} {self._config.data[CONF_ROAD_NAME]} {self._config.data[CONF_HOUSE_NUMBER]}",
+            name=name,
             configuration_url="https://github.com/briis/affalddk",
         )
 

--- a/custom_components/affalddk/config_flow.py
+++ b/custom_components/affalddk/config_flow.py
@@ -44,14 +44,14 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def municipalityFromCoor(lon, lat):
+async def municipalityFromCoor(lon, lat):
     """Municipality from longitude and latitude."""
 
     url = f"https://api.dataforsyningen.dk/kommuner/reverse?x={lon}&y={lat}"
     async with aiohttp.ClientSession() as session, session.get(url) as response:
         if response.status == 200:
             js = await response.json()
-            return js.get("navn", '')
+            return js.get("navn", '').capitalize()
 
 
 class AffaldDKFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -67,8 +67,7 @@ class AffaldDKFlowHandler(ConfigFlow, domain=DOMAIN):
 
         municipality = user_input.get(CONF_MUNICIPALITY)
         if not municipality:
-            server_municipality = await self.hass.async_add_executor_job(
-                municipalityFromCoor,
+            server_municipality = await municipalityFromCoor(
                 self.hass.config.longitude,
                 self.hass.config.latitude,
             )

--- a/custom_components/affalddk/config_flow.py
+++ b/custom_components/affalddk/config_flow.py
@@ -41,6 +41,7 @@ from .const import (
     DOMAIN,
 )
 
+GOBACK = '<- Tilbage'
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -130,7 +131,7 @@ class AffaldDKFlowHandler(ConfigFlow, domain=DOMAIN):
             if len(address_list) == 1:
                 return await self._create_entry(address_list[0])
             elif len(address_list) > 1:
-                return await self.async_step_select_address(options=['tilbage..'] + address_list)
+                return await self.async_step_select_address(options=[GOBACK] + address_list)
             else:
                 errors["base"] = "location_not_found"
 
@@ -147,7 +148,7 @@ class AffaldDKFlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_select_address(self, user_input=None, options=[]):
         """Handle a flow initialized by the select address."""
         if user_input is not None:
-            if user_input['address'] == 'tilbage..':
+            if user_input['address'] == GOBACK:
                 return await self.async_step_user(user_input=self.user_input, from_select=True)
             return await self._create_entry(user_input['address'])
 

--- a/custom_components/affalddk/config_flow.py
+++ b/custom_components/affalddk/config_flow.py
@@ -20,7 +20,6 @@ from homeassistant.helpers.selector import selector
 
 from pyaffalddk import (
     GarbageCollection,
-    AffaldDKAddressInfo,
     AffaldDKNotSupportedError,
     AffaldDKNotValidAddressError,
     AffaldDKNoConnection,
@@ -28,6 +27,7 @@ from pyaffalddk import (
 from pyaffalddk.municipalities import MUNICIPALITIES_LIST
 
 from .const import (
+    CONF_ADDRESS,
     CONF_ADDRESS_ID,
     CONF_CALENDAR_END_TIME,
     CONF_CALENDAR_START_TIME,
@@ -49,78 +49,97 @@ class AffaldDKFlowHandler(ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     @callback
-    def _show_setup_form(
-            self,
-            user_input: dict[str, Any] | None = None,
-            errors: dict[str, str] | None = None,
-    ) -> ConfigFlowResult:
+    def _show_setup_form(self, user_input={}, errors={}) -> ConfigFlowResult:
         """Show the setup form to the user."""
 
-        if user_input is None:
-            user_input = {}
-
         options = [key for key, val in MUNICIPALITIES_LIST.items()]
+        schema = vol.Schema({
+            vol.Required(CONF_MUNICIPALITY, default=user_input.get(CONF_MUNICIPALITY)): selector(
+                {"select": {"options": options}}
+            ),
+            vol.Required(CONF_ZIPCODE, default=user_input.get(CONF_ZIPCODE, '')): str,
+            vol.Required(CONF_ROAD_NAME, default=user_input.get(CONF_ROAD_NAME, '')): str,
+            vol.Optional(CONF_HOUSE_NUMBER, default=user_input.get(CONF_HOUSE_NUMBER, '')): str,
+        })
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_MUNICIPALITY): selector(
-                        {"select": {"options": options}}
-                    ),
-                    vol.Required(CONF_ZIPCODE): str,
-                    vol.Required(CONF_ROAD_NAME): str,
-                    vol.Required(CONF_HOUSE_NUMBER): str,
-                }
-            ),
+            data_schema=schema,
             errors=errors or {},
         )
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None):
-        """Handle a flow initialized by the user."""
-        errors: dict[str, str] = {}
-
-        if user_input is None:
-            return self._show_setup_form(user_input, errors)
-
-        municipality = user_input[CONF_MUNICIPALITY]
-        zipcode = user_input[CONF_ZIPCODE].strip()
-        street = user_input[CONF_ROAD_NAME].strip()
-        house_number = user_input[CONF_HOUSE_NUMBER].strip()
-
-        try:
-            session = async_create_clientsession(self.hass)
-            affalddkapi = await self.hass.async_add_executor_job(
-                lambda: GarbageCollection(
-                    municipality=municipality, session=session
-                )
-            )
-            await affalddkapi.async_init()
-            address_info: AffaldDKAddressInfo = await affalddkapi.get_address_id(
-                zipcode=zipcode,
-                street=street,
-                house_number=house_number,
-            )
-        except AffaldDKNotSupportedError:
-            errors["base"] = "municipality_not_supported"
-            return self._show_setup_form(errors)
-        except AffaldDKNotValidAddressError:
-            errors["base"] = "location_not_found"
-            return self._show_setup_form(errors)
-        except AffaldDKNoConnection:
-            errors["base"] = "connection_error"
-            return self._show_setup_form(errors)
-
+    async def _create_entry(self, address_name) -> ConfigEntry:
+        address_info = await self.affalddkapi.get_address(address_name)
         await self.async_set_unique_id(address_info.uid)
         self._abort_if_unique_id_configured
 
         return self.async_create_entry(
-            title=f"{address_info.vejnavn} {address_info.husnr}",
+            title=address_info.address,
             data={
                 CONF_MUNICIPALITY: address_info.kommunenavn,
-                CONF_ROAD_NAME: address_info.vejnavn,
-                CONF_HOUSE_NUMBER: address_info.husnr,
+                CONF_ADDRESS: address_info.address,
                 CONF_ADDRESS_ID: address_info.address_id,
             },
+        )
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None, from_select=False):
+        """Handle a flow initialized by the user."""
+        _LOGGER.debug(f'USER: {user_input}')
+        errors: dict[str, str] = {}
+
+        if user_input is None:
+            return self._show_setup_form()
+        if from_select:
+            return self._show_setup_form(user_input=user_input)
+
+        municipality = user_input[CONF_MUNICIPALITY]
+        zipcode = user_input[CONF_ZIPCODE].strip()
+        street = user_input[CONF_ROAD_NAME].strip()
+        house_number = user_input.get(CONF_HOUSE_NUMBER, '').strip()
+        self.user_input = user_input
+        try:
+            session = async_create_clientsession(self.hass)
+            self.affalddkapi = await self.hass.async_add_executor_job(
+                lambda: GarbageCollection(
+                    municipality=municipality, session=session
+                )
+            )
+            await self.affalddkapi.async_init()
+            address_list = await self.affalddkapi.get_address_list(
+                zipcode=zipcode, street=street, house_number=house_number,
+            )
+            if len(address_list) == 1:
+                return await self._create_entry(address_list[0])
+            elif len(address_list) > 1:
+                return await self.async_step_select_address(options=['tilbage..'] + address_list)
+            else:
+                errors["base"] = "location_not_found"
+
+        except AffaldDKNotSupportedError:
+            errors["base"] = "municipality_not_supported"
+        except AffaldDKNotValidAddressError:
+            errors["base"] = "location_not_found"
+        except AffaldDKNoConnection:
+            errors["base"] = "connection_error"
+
+        if errors:
+            return self._show_setup_form(user_input=user_input, errors=errors)
+
+    async def async_step_select_address(self, user_input=None, options=[]):
+        """Handle a flow initialized by the select address."""
+        _LOGGER.debug(f'SELECT: {user_input}')
+        if user_input is not None:
+            if user_input['address'] == 'tilbage..':
+                return await self.async_step_user(user_input=self.user_input, from_select=True)
+            return await self._create_entry(user_input['address'])
+
+        return self.async_show_form(
+            step_id="select_address",
+            description_placeholders=self.user_input,
+            data_schema=vol.Schema({
+                vol.Required(CONF_ADDRESS): selector(
+                    {"select": {"options": options}}
+                )
+            })
         )
 
     @staticmethod
@@ -145,12 +164,6 @@ class OptionsFlowHandler(OptionsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    # vol.Optional(
-                    #     CONF_UPDATE_INTERVAL,
-                    #     default=self.config_entry.options.get(
-                    #         CONF_UPDATE_INTERVAL, DEFAULT_SCAN_INTERVAL
-                    #     ),
-                    # ): vol.All(vol.Coerce(int), vol.Range(min=1, max=24)),
                     vol.Optional(
                         CONF_CALENDAR_START_TIME,
                         default=self.config_entry.options.get(

--- a/custom_components/affalddk/manifest.json
+++ b/custom_components/affalddk/manifest.json
@@ -12,7 +12,7 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/briis/affalddk/issues",
     "requirements": [
-        "bs4",
+        "beautifulsoup4",
         "pyaffalddk==2.10.5"
     ],
     "version": "2.7.0-beta-1"

--- a/custom_components/affalddk/manifest.json
+++ b/custom_components/affalddk/manifest.json
@@ -13,7 +13,7 @@
     "issue_tracker": "https://github.com/briis/affalddk/issues",
     "requirements": [
         "beautifulsoup4",
-        "pyaffalddk==2.10.5"
+        "pyaffalddk==2.11.0"
     ],
-    "version": "2.7.0-beta-1"
+    "version": "2.7.0-beta-2"
 }

--- a/custom_components/affalddk/sensor.py
+++ b/custom_components/affalddk/sensor.py
@@ -33,6 +33,7 @@ from .const import (
     ATTR_DESCRIPTION,
     ATTR_DURATION,
     ATTR_LAST_UPDATE,
+    CONF_ADDRESS,
     CONF_ADDRESS_ID,
     CONF_HOUSE_NUMBER,
     CONF_MUNICIPALITY,
@@ -282,15 +283,17 @@ class AffaldDKSensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity):
         self._config = config
         self._coordinator = coordinator
         self._pickup_events: PickupType = None
-
+        name = DOMAIN.capitalize()
+        if CONF_ADDRESS in self._config.data:
+            name += f" {self._config.data[CONF_ADDRESS]}"
+        else:
+            # backwards compatible
+            name += f" {self._config.data[CONF_ROAD_NAME]} {self._config.data[CONF_HOUSE_NUMBER]}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._config.data[CONF_ADDRESS_ID])},
             entry_type=DeviceEntryType.SERVICE,
             manufacturer=DEFAULT_BRAND,
-            name=(
-                f"{DOMAIN.capitalize()} {self._config.data[CONF_ROAD_NAME]} "
-                f"{self._config.data[CONF_HOUSE_NUMBER]}"
-            ),
+            name=name,
             configuration_url="https://github.com/briis/affalddk",
             model=f"Kommune: {config.data[CONF_MUNICIPALITY]}",
             model_id=f"ID: {config.data[CONF_ADDRESS_ID]}",

--- a/custom_components/affalddk/translations/da.json
+++ b/custom_components/affalddk/translations/da.json
@@ -14,11 +14,17 @@
                     "zipcode": "Postnummer",
                     "road_name": "Vej navn",
                     "house_number": "Hus nummer",
-                    "update_interval": "Opdaterings interval (timer)",
                     "calendar_end_time": "Tømmings slut tid",
                     "calendar_start_time": "Tømmings start tid"
                 },
                 "description": "Hent affalds opsamlingsdata fra danske kommuner.",
+                "title": "Affald DK"
+            },
+            "select_option": {
+                "data": {
+                    "address": "Vælg Addresse"
+                },
+                "description": "{municipality} -- Postnummer: {zipcode}",
                 "title": "Affald DK"
             }
         }
@@ -31,7 +37,6 @@
                     "zipcode": "Postnummer",
                     "road_name": "Vej navn",
                     "house_number": "Hus nummer",
-                    "update_interval": "Opdaterings interval (timer)",
                     "calendar_end_time": "Tømmings slut tid",
                     "calendar_start_time": "Tømmings start tid"
                 }

--- a/custom_components/affalddk/translations/da.json
+++ b/custom_components/affalddk/translations/da.json
@@ -20,11 +20,11 @@
                 "description": "Hent affalds opsamlingsdata fra danske kommuner.",
                 "title": "Affald DK"
             },
-            "select_option": {
+            "select_address": {
                 "data": {
                     "address": "Vælg Addresse"
                 },
-                "description": "{municipality} -- Postnummer: {zipcode}",
+                "description": "{municipality}\nVej navn: \"{road_name}\"\nHus nummer: \"{house_number}\"\nPostnummer: \"{zipcode}\"",
                 "title": "Affald DK"
             }
         }

--- a/custom_components/affalddk/translations/en.json
+++ b/custom_components/affalddk/translations/en.json
@@ -20,11 +20,11 @@
                 "description": "Setup Home Assistant to collect Garbage Pick-Up data from Danish Municipalities.",
                 "title": "Affald DK"
             },
-            "select_option": {
+            "select_address": {
                 "data": {
                     "address": "Select Address"
                 },
-                "description": "{municipality} -- Zipcode: {zipcode}",
+                "description": "{municipality}\nRoad name: \"{road_name}\"\nHouse Number: \"{house_number}\"\nZipcode: \"{zipcode}\"",
                 "title": "Affald DK"
             }
         }

--- a/custom_components/affalddk/translations/en.json
+++ b/custom_components/affalddk/translations/en.json
@@ -14,11 +14,17 @@
                     "zipcode": "Zipcode",
                     "road_name": "Road name",
                     "house_number": "House Number",
-                    "update_interval": "Update Interval (Hours)",
                     "calendar_end_time": "Pickup end time",
                     "calendar_start_time": "Pickup start time"
                 },
                 "description": "Setup Home Assistant to collect Garbage Pick-Up data from Danish Municipalities.",
+                "title": "Affald DK"
+            },
+            "select_option": {
+                "data": {
+                    "address": "Select Address"
+                },
+                "description": "{municipality} -- Zipcode: {zipcode}",
                 "title": "Affald DK"
             }
         }
@@ -31,7 +37,6 @@
                     "zipcode": "Zipcode",
                     "road_name": "Road name",
                     "house_number": "House Number",
-                    "update_interval": "Update Interval (Hours)",
                     "calendar_end_time": "Pickup end time",
                     "calendar_start_time": "Pickup start time"
                 }


### PR DESCRIPTION
Med dette nye config flow som kræver breaking changes fra pyaffald (virker lige nu kun med [address_list](https://github.com/briis/pyaffalddk/tree/address_lists) branch fra der), bliver husnummer som input optional, og selv hvis der er givet et nummer vil mange af vores api'er returnere en liste nu.

Hvis man fra input får mere end et resultat, vil man nu blive sendt videre til en selector med de fundne addresser, og med et tilbage valg øverst. Dette er sådan den slags vist kun kan gøres i et HA config flow.

Jeg har også fikset så de tidligere indsatte værdier vil forblive hvis man får en fejl (ingen resultat eller lignende fra api) og når man returnerer fra selector step.

@briis du må meget gerne lege lidt med det både herfra og i pyaffald.

dette vil fixe:
- https://github.com/briis/affalddk/issues/323