### PR TITLE
Fix calendar trigger not firing: use overlap in async_get_events

### DIFF
--- a/custom_components/affalddk/calendar.py
+++ b/custom_components/affalddk/calendar.py
@@ -115,7 +115,7 @@ class AffaldDKCalendar(CoordinatorEntity[DataUpdateCoordinator], CalendarEntity)
             if event and name != "next_pickup":
                 event_start = dt.combine(event.date, time(self._start_time, 0, 0)).replace(tzinfo=get_default_time_zone())
                 event_end = dt.combine(event.date, time(self._end_time, 0, 0)).replace(tzinfo=get_default_time_zone())
-                if (start_date <= event_start) and (end_date >= event_end):
+                if event_start < end_date and event_end > start_date:
                     events.append(
                         CalendarEvent(
                             summary=event.friendly_name,


### PR DESCRIPTION
The `calendar` start trigger never fires for this integration's calendar, though the entity goes to `on` at pickup time.

`async_get_events` uses a containment test instead of overlap, so it returns `[]` for the trigger's 15-min poll windows (which rarely fully contain a multi-hour event). Switch to an overlap test.

Verified locally: `calendar.get_events` now returns the event for a window covering its start, and the trigger arms.

Related HA issue: https://github.com/home-assistant/core/issues/167903