### PR TITLE
Add English localisation for waste types and calendar entriesEn localisations

### DIFF
--- a/custom_components/affalddk/__init__.py
+++ b/custom_components/affalddk/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+import json
 import logging
 from pathlib import Path
 from typing import Self
@@ -26,6 +27,8 @@ from .const import (
     CONF_ADDRESS_ID,
     CONF_MUNICIPALITY,
     CONF_DYNAMIC_NEXT_EVENT_ICON,
+    CONF_UNIT_LANGUAGE,
+    DEFAULT_UNIT_LANGUAGE,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
@@ -33,6 +36,12 @@ from .const import (
 PLATFORMS = [Platform.SENSOR, Platform.CALENDAR]
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def load_waste_names(language: str) -> dict[str, str]:
+    """Load waste type translations."""
+    with (Path(__file__).parent / "translations" / f"{language}.json").open(encoding="utf-8") as translation_file:
+        return json.load(translation_file)["entity"]["sensor"]["waste_type"]["state"]
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -43,6 +52,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         await coordinator.async_config_entry_first_refresh()
     else:
         await coordinator.async_refresh()
+
+    language = config_entry.options.get(CONF_UNIT_LANGUAGE, DEFAULT_UNIT_LANGUAGE)
+    coordinator.waste_names = await hass.async_add_executor_job(load_waste_names, language)
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][config_entry.entry_id] = coordinator

--- a/custom_components/affalddk/calendar.py
+++ b/custom_components/affalddk/calendar.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import datetime
 from datetime import datetime as dt, time
-import json
 import logging
-from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 
@@ -28,12 +26,10 @@ from .const import (
     CONF_CALENDAR_START_TIME,
     CONF_HOUSE_NUMBER,
     CONF_ROAD_NAME,
-    CONF_UNIT_LANGUAGE,
     DEFAULT_ATTRIBUTION,
     DEFAULT_BRAND,
     DEFAULT_END_TIME,
     DEFAULT_START_TIME,
-    DEFAULT_UNIT_LANGUAGE,
     DOMAIN,
 )
 from .pyaffalddk.const import NAME_LIST_REV
@@ -73,9 +69,7 @@ class AffaldDKCalendar(CoordinatorEntity[DataUpdateCoordinator], CalendarEntity)
         super().__init__(coordinator)
         self._config = config
         self._coordinator = coordinator
-        language = self._config.options.get(CONF_UNIT_LANGUAGE, DEFAULT_UNIT_LANGUAGE)
-        with (Path(__file__).parent / "translations" / f"{language}.json").open(encoding="utf-8") as translation_file:
-            self._waste_names = json.load(translation_file)["entity"]["sensor"]["waste_type"]["state"]
+        self._waste_names = coordinator.waste_names
         name = DOMAIN.capitalize()
         if CONF_ADDRESS in self._config.data:
             name += f" {self._config.data[CONF_ADDRESS]}"

--- a/custom_components/affalddk/calendar.py
+++ b/custom_components/affalddk/calendar.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import datetime
 from datetime import datetime as dt, time
+import json
 import logging
+from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 
@@ -26,12 +28,15 @@ from .const import (
     CONF_CALENDAR_START_TIME,
     CONF_HOUSE_NUMBER,
     CONF_ROAD_NAME,
+    CONF_UNIT_LANGUAGE,
     DEFAULT_ATTRIBUTION,
     DEFAULT_BRAND,
     DEFAULT_END_TIME,
     DEFAULT_START_TIME,
+    DEFAULT_UNIT_LANGUAGE,
     DOMAIN,
 )
+from .pyaffalddk.const import NAME_LIST_REV
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -68,6 +73,9 @@ class AffaldDKCalendar(CoordinatorEntity[DataUpdateCoordinator], CalendarEntity)
         super().__init__(coordinator)
         self._config = config
         self._coordinator = coordinator
+        language = self._config.options.get(CONF_UNIT_LANGUAGE, DEFAULT_UNIT_LANGUAGE)
+        with (Path(__file__).parent / "translations" / f"{language}.json").open(encoding="utf-8") as translation_file:
+            self._waste_names = json.load(translation_file)["entity"]["sensor"]["waste_type"]["state"]
         name = DOMAIN.capitalize()
         if CONF_ADDRESS in self._config.data:
             name += f" {self._config.data[CONF_ADDRESS]}"
@@ -88,6 +96,10 @@ class AffaldDKCalendar(CoordinatorEntity[DataUpdateCoordinator], CalendarEntity)
         self._end_time = self._config.options.get(CONF_CALENDAR_END_TIME, DEFAULT_END_TIME)
         self._start_time = self._config.options.get(CONF_CALENDAR_START_TIME, DEFAULT_START_TIME)
 
+    def _event_name(self, event) -> str:
+        """Return translated waste type name."""
+        return " | ".join(self._waste_names.get(NAME_LIST_REV.get(name), name) for name in event.friendly_name.split(" | "))
+
     @property
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
@@ -95,7 +107,7 @@ class AffaldDKCalendar(CoordinatorEntity[DataUpdateCoordinator], CalendarEntity)
             _start_dt = dt.combine(next_pickup.date, time(self._start_time, 0, 0)).replace(tzinfo=get_default_time_zone())
             _end_dt = dt.combine(next_pickup.date, time(self._end_time, 0, 0)).replace(tzinfo=get_default_time_zone())
             return CalendarEvent(
-                summary=next_pickup.friendly_name,
+                summary=self._event_name(next_pickup),
                 description=next_pickup.description,
                 start=_start_dt,
                 end=_end_dt,
@@ -118,7 +130,7 @@ class AffaldDKCalendar(CoordinatorEntity[DataUpdateCoordinator], CalendarEntity)
                 if event_start < end_date and event_end > start_date:
                     events.append(
                         CalendarEvent(
-                            summary=event.friendly_name,
+                            summary=self._event_name(event),
                             description=event.description,
                             start=event_start,
                             end=event_end,

--- a/custom_components/affalddk/sensor.py
+++ b/custom_components/affalddk/sensor.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import json
 import logging
 
 from dataclasses import dataclass
 import datetime
 from datetime import datetime as dt
-from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 
@@ -272,9 +270,7 @@ class AffaldDKSensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity):
         self._coordinator = coordinator
         self._pickup_events: PickupType = None
         self._da = config.options.get(CONF_UNIT_LANGUAGE, DEFAULT_UNIT_LANGUAGE) == DEFAULT_UNIT_LANGUAGE
-        language = self._config.options.get(CONF_UNIT_LANGUAGE, DEFAULT_UNIT_LANGUAGE)
-        with (Path(__file__).parent / "translations" / f"{language}.json").open(encoding="utf-8") as translation_file:
-            self._waste_names = json.load(translation_file)["entity"]["sensor"]["waste_type"]["state"]
+        self._waste_names = coordinator.waste_names
         self._attr_name = self._waste_names.get(description.key, description.name)
         name = DOMAIN.capitalize()
         if CONF_ADDRESS in self._config.data:

--- a/custom_components/affalddk/sensor.py
+++ b/custom_components/affalddk/sensor.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import logging
 
 from dataclasses import dataclass
 import datetime
 from datetime import datetime as dt
+from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 
@@ -49,6 +51,7 @@ from .const import (
 from .pyaffalddk.data import PickupEvents
 from .pyaffalddk.const import (
     ICON_LIST,
+    NAME_LIST_REV,
     WEEKDAYS,
     WEEKDAYS_SHORT,
 )
@@ -269,6 +272,10 @@ class AffaldDKSensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity):
         self._coordinator = coordinator
         self._pickup_events: PickupType = None
         self._da = config.options.get(CONF_UNIT_LANGUAGE, DEFAULT_UNIT_LANGUAGE) == DEFAULT_UNIT_LANGUAGE
+        language = self._config.options.get(CONF_UNIT_LANGUAGE, DEFAULT_UNIT_LANGUAGE)
+        with (Path(__file__).parent / "translations" / f"{language}.json").open(encoding="utf-8") as translation_file:
+            self._waste_names = json.load(translation_file)["entity"]["sensor"]["waste_type"]["state"]
+        self._attr_name = self._waste_names.get(description.key, description.name)
         name = DOMAIN.capitalize()
         if CONF_ADDRESS in self._config.data:
             name += f" {self._config.data[CONF_ADDRESS]}"
@@ -285,6 +292,10 @@ class AffaldDKSensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity):
             model_id=f"ID: {config.data[CONF_ADDRESS_ID]}",
         )
         self._attr_unique_id = unique_id(config, description)
+
+    def _event_name(self, event) -> str:
+        """Return translated waste type name."""
+        return " | ".join(self._waste_names.get(NAME_LIST_REV.get(name), name) for name in event.friendly_name.split(" | "))
 
     @property
     def event(self) -> PickupEvents | None:
@@ -360,7 +371,7 @@ class AffaldDKSensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity):
             att[ATTR_DATE_SHORT] = f"{_day_name} {_date.strftime('d. %d/%m') if _date else None}"
             att[ATTR_DESCRIPTION] = self.event.description
             att[ATTR_DURATION] = _day_text
-            att[ATTR_NAME] = self.event.friendly_name
+            att[ATTR_NAME] = self._event_name(self.event)
             att[ATTR_ENTITY_PICTURE] = f'/affalddk/img/{self.event.group}.svg'
             if self.event.container_count is not None:
                 att[ATTR_CONTAINER_COUNT] = self.event.container_count

--- a/custom_components/affalddk/translations/da.json
+++ b/custom_components/affalddk/translations/da.json
@@ -29,6 +29,53 @@
             }
         }
     },
+    "entity": {
+        "sensor": {
+            "waste_type": {
+                "state": {
+                    "batterier": "Batterier",
+                    "bioposer": "Bioposer",
+                    "dagrenovation": "Dagrenovation",
+                    "elektronik": "Elektronik",
+                    "farligtaffald": "Farligt affald",
+                    "farligtaffaldmiljoboks": "Farligt affald & Miljøboks",
+                    "flis": "Flis",
+                    "genbrug": "Genbrug",
+                    "glas": "Glas",
+                    "glasplast": "Glas, Plast & Madkartoner",
+                    "haveaffald": "Haveaffald",
+                    "jern": "Jern",
+                    "juletrae": "Juletræer",
+                    "madaffald": "Madaffald",
+                    "metal": "Metal",
+                    "metalglas": "Metal & Glas",
+                    "pap": "Pap",
+                    "pappapir": "Pap & Papir",
+                    "pappapirglasmetal": "Pap, Papir, Glas & Metal",
+                    "pappapirtekstil": "Pap, Papir & Tekstilaffald",
+                    "pappi": "Papir & Plast",
+                    "papir": "Papir",
+                    "papirglas": "Papir, Pap & Glas",
+                    "papirglasdaaser": "Papir, Glas & Dåser",
+                    "papirglasmetalplast": "Papir, Glas, Metal & Plast",
+                    "papirmetal": "Papir & Metal",
+                    "plast": "Plast",
+                    "plastmadkarton": "Plast & Madkarton",
+                    "plastmdkglasmetal": "Plast, Madkarton, Glas & Metal",
+                    "plastmetal": "Plast & Metal",
+                    "plastmetalmdk": "Plast, Metal, Mad & Drikkekartoner",
+                    "plastmetalpapir": "Plast, Metal & Papir",
+                    "restaffald": "Restaffald",
+                    "restaffaldmadaffald": "Rest & Madaffald",
+                    "restplast": "Restaffald & Plast/Madkartoner",
+                    "storskrald": "Storskrald",
+                    "storskraldogfarligtaffald": "Storskrald & Farligt affald",
+                    "storskraldogtekstilaffald": "Storskrald & Tekstilaffald",
+                    "tekstil": "Tekstilaffald"
+                }
+            }
+        }
+    },
     "options": {
         "step": {
             "init": {

--- a/custom_components/affalddk/translations/en.json
+++ b/custom_components/affalddk/translations/en.json
@@ -29,6 +29,53 @@
             }
         }
     },
+    "entity": {
+        "sensor": {
+            "waste_type": {
+                "state": {
+                    "batterier": "Batteries",
+                    "bioposer": "Bio bags",
+                    "dagrenovation": "Household waste",
+                    "elektronik": "Electronics",
+                    "farligtaffald": "Hazardous waste",
+                    "farligtaffaldmiljoboks": "Hazardous waste & environmental box",
+                    "flis": "Wood chips",
+                    "genbrug": "Recycling",
+                    "glas": "Glass",
+                    "glasplast": "Glass, plastic & food cartons",
+                    "haveaffald": "Garden waste",
+                    "jern": "Iron",
+                    "juletrae": "Christmas trees",
+                    "madaffald": "Food waste",
+                    "metal": "Metal",
+                    "metalglas": "Metal & glass",
+                    "pap": "Cardboard",
+                    "pappapir": "Cardboard & paper",
+                    "pappapirglasmetal": "Cardboard, paper, glass & metal",
+                    "pappapirtekstil": "Cardboard, paper & textile waste",
+                    "pappi": "Paper & plastic",
+                    "papir": "Paper",
+                    "papirglas": "Paper, cardboard & glass",
+                    "papirglasdaaser": "Paper, glass & cans",
+                    "papirglasmetalplast": "Paper, glass, metal & plastic",
+                    "papirmetal": "Paper & metal",
+                    "plast": "Plastic",
+                    "plastmadkarton": "Plastic & food cartons",
+                    "plastmdkglasmetal": "Plastic, food cartons, glass & metal",
+                    "plastmetal": "Plastic & metal",
+                    "plastmetalmdk": "Plastic, metal, food & beverage cartons",
+                    "plastmetalpapir": "Plastic, metal & paper",
+                    "restaffald": "Residual waste",
+                    "restaffaldmadaffald": "Residual & food waste",
+                    "restplast": "Residual waste & plastic/food cartons",
+                    "storskrald": "Bulky waste",
+                    "storskraldogfarligtaffald": "Bulky & hazardous waste",
+                    "storskraldogtekstilaffald": "Bulky & textile waste",
+                    "tekstil": "Textile waste"
+                }
+            }
+        }
+    },
     "options": {
         "step": {
             "init": {
@@ -40,7 +87,7 @@
                     "calendar_end_time": "Pickup end time",
                     "calendar_start_time": "Pickup start time",
                     "dynamic_next_event_icon": "Show first fraction type icon for next event",
-                    "unit_language": "Unit language"
+                    "unit_language": "Display language"
                 }
             }
         }


### PR DESCRIPTION
## Description

This PR extends the existing language option so that it controls the display language for waste types in addition to the existing unit and relative date text.

Previously, selecting English changed values such as `day`, `days`, `Today`, and `Tomorrow`, while waste type names and calendar entries remained in Danish.

With this change, selecting English also translates the waste type names used by sensors and calendar events.

## Changes

- Added English translations for waste types.
- Added corresponding Danish waste type translations.
- Waste sensor friendly names now follow the selected language.
- The sensor `name` attribute now follows the selected language.
- Calendar event summaries now follow the selected language.
- Combined waste types are translated individually.
- Changed the English option label from `Unit language` to `Display language` to better reflect what the option now controls.
- Kept the existing `unit_language` configuration key for backwards compatibility.

## Examples

When English is selected:

- `Restaffald` → `Residual waste`
- `Madaffald` → `Food waste`
- `Papir` → `Paper`
- `Madaffald | Restaffald` → `Food waste | Residual waste`

Calendar entries use the same translated names.

When Danish is selected, the existing Danish names are retained.

## Implementation

Waste type translations are stored in the existing Home Assistant translation files:

- `translations/en.json`
- `translations/da.json`

The selected translation data is loaded during integration setup and reused by the sensor and calendar platforms.

This avoids changing the internal waste type identifiers and keeps the existing API/data handling unchanged.

## Backwards compatibility

The existing `unit_language` configuration key and the internal waste type keys are unchanged, so existing configurations continue to work without migration.